### PR TITLE
Objective-C: Better class registration.

### DIFF
--- a/lab-jit-objc/fixture/SomeClass.hpp
+++ b/lab-jit-objc/fixture/SomeClass.hpp
@@ -1,11 +1,21 @@
 #include <Cocoa/Cocoa.h>
 #include <CoreFoundation/CoreFoundation.h>
 
-@interface SomeClass : NSObject
+@interface FirstClass : NSObject
+@property (nonatomic, strong) NSString *theSameProperty;
+@property (nonatomic, strong) NSString *uniqueProperty1;
 + (void)clazzMethod;
 - (BOOL)hello;
-- (void)printHello;
 @end
 
-@interface FooClass : NSObject
+@interface FirstClass_Subclass : FirstClass
+@property (nonatomic, strong) NSString *uniqueProperty2;
++ (void)clazzMethod;
+- (BOOL)hello;
+@end
+
+@interface FirstClass_Subclass_Subclass : FirstClass_Subclass
+@property (nonatomic, strong) NSString *uniqueProperty3;
++ (void)clazzMethod;
+- (BOOL)hello;
 @end

--- a/lab-jit-objc/fixture/SomeClass.mm
+++ b/lab-jit-objc/fixture/SomeClass.mm
@@ -2,29 +2,68 @@
 
 #import <XCTest/XCTest.h>
 
-@implementation SomeClass
+@implementation FirstClass_Subclass_Subclass
+- (id)init {
+    self = [super init];
+    self.uniqueProperty3 = @"FirstClass_Subclass_Subclass@uniqueProperty";
+    return self;
+}
 + (void)clazzMethod {
-
+    [super clazzMethod];
+    NSLog(@"FirstClass_Subclass_Subclass +clazzMethod\n");
 }
+
 - (BOOL)hello {
-	[self printHello];
-	return YES;
+    [super hello];
+    NSLog(@"FirstClass_Subclass_Subclass -hello: %@ %@\n",
+           self.theSameProperty, self.uniqueProperty3);
+    return YES;
 }
-- (void)printHello {
-	printf("hello sir!\n");
-}
-
 @end
 
-@implementation FooClass; @end
+@implementation FirstClass
+- (id)init {
+    self = [super init];
+    self.theSameProperty = @"The same property";
+    self.uniqueProperty1 = @"FirstClass@uniqueProperty";
+    return self;
+}
++ (void)clazzMethod {
+    NSLog(@"FirstClass +clazzMethod\n");
+}
+- (BOOL)hello {
+    NSLog(@"FirstClass -hello: %@ %@\n",
+           self.theSameProperty, self.uniqueProperty1);
+    return YES;
+}
+@end
+
+@implementation FirstClass_Subclass
+- (id)init {
+    self = [super init];
+    self.uniqueProperty2 = @"FirstClass_Subclass@uniqueProperty";
+    return self;
+}
++ (void)clazzMethod {
+    [super clazzMethod];
+    NSLog(@"FirstClass_Subclass +clazzMethod\n");
+}
+
+- (BOOL)hello {
+    [super hello];
+    NSLog(@"FirstClass_Subclass -hello: %@ %@\n",
+           self.theSameProperty, self.uniqueProperty2);
+    return YES;
+}
+@end
 
 @interface FooTest : XCTestCase
 @end
 
 @implementation FooTest
 - (void)testFoo {
-  printf("Success! Runtime sees the FooTest class!\n");
-  XCTAssert([[SomeClass new] hello]);
+  NSLog(@"Success! Runtime sees the FooTest class!\n");
+  XCTAssert([[FirstClass_Subclass_Subclass new] hello]);
 }
 - (void)testFoo2 {
   XCTAssert(NO);

--- a/lab-jit-objc/fixture/jitobjc.mm
+++ b/lab-jit-objc/fixture/jitobjc.mm
@@ -10,10 +10,6 @@
 #import "MUT_XCTestDriver.h"
 
 extern "C" void objc_function () {
-
-    SomeClass *someClass = [SomeClass new];
-    [someClass hello];
-
 	printf("before test call\n");
 	MUT_RunXCTests();
 	printf("after test call\n");

--- a/lab-jit-objc/llvm-jit-lab/src/ObjCEnabledMemoryManager.cpp
+++ b/lab-jit-objc/llvm-jit-lab/src/ObjCEnabledMemoryManager.cpp
@@ -55,7 +55,9 @@ void ObjCEnabledMemoryManager::registerObjC() {
 
   for (ObjectSectionEntry &entry: objcSections) {
     if (entry.section.find("__objc_classlist") != StringRef::npos) {
-      runtime.registerClasses(entry.pointer, entry.size);
+      runtime.addClassesFromSection(entry.pointer, entry.size);
     }
   }
+
+  runtime.registerClasses();
 }

--- a/lab-jit-objc/llvm-jit-lab/src/ObjCRuntime.h
+++ b/lab-jit-objc/llvm-jit-lab/src/ObjCRuntime.h
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <iomanip>
 #include <string>
+#include <queue>
 
 using namespace llvm;
 
@@ -174,12 +175,19 @@ struct class64_t {
 namespace mull { namespace objc {
 
 class Runtime {
+  std::queue<class64_t *> classesToRegister;
+
+  void registerOneClass(class64_t *isaPtr, Class superclass);
+
+
 public:
   void registerSelectors(void *selRefsSectionPtr,
                          uintptr_t selRefsSectionSize);
 
-  void registerClasses(void *classListSectionPtr,
-                       uintptr_t classListSectionSize);
+  void addClassesFromSection(void *sectionPtr,
+                             uintptr_t sectionSize);
+
+  void registerClasses();
 };
 
 } }


### PR DESCRIPTION
```
Running main() from gtest_main.cc
[0;32m[==========] [mRunning 1 test from 1 test case.
[0;32m[----------] [mGlobal test environment set-up.
[0;32m[----------] [m1 test from LLVMJIT
[0;32m[ RUN      ] [mLLVMJIT.ObjCRegistration
ModuleLoader> module /opt/jitobjc.bc
ModuleLoader> module /opt/SomeClass.bc
MullMemoryManager::allocateDataSection(objc) -- __objc_const pointer: 0x1017db168 size: 2112
MullMemoryManager::allocateDataSection(objc) -- __objc_data pointer: 0x1017db9a8 size: 576
MullMemoryManager::allocateDataSection(objc) -- __objc_ivar pointer: 0x1017dbbe8 size: 32
MullMemoryManager::allocateDataSection(objc) -- __objc_selrefs pointer: 0x1017dbea8 size: 240
MullMemoryManager::allocateDataSection(objc) -- __objc_classrefs pointer: 0x1017dbf98 size: 32
MullMemoryManager::allocateDataSection(objc) -- __objc_superrefs pointer: 0x1017dc280 size: 80
MullMemoryManager::allocateDataSection(objc) -- __objc_methname pointer: 0x1017dc2d0 size: 287
MullMemoryManager::allocateDataSection(objc) -- __objc_classname pointer: 0x1017dbfb8 size: 68
MullMemoryManager::allocateDataSection(objc) -- __objc_methtype pointer: 0x1017dc3ef size: 47
MullMemoryManager::allocateDataSection(objc) -- __objc_classlist pointer: 0x1017dc420 size: 64
MullMemoryManager::registerObjC()
__objc_const
__objc_data
__objc_ivar
__objc_selrefs
Trying to register selector: 0x1017dc2d0/init
Trying to register selector: 0x1017dc2d5/setUniqueProperty3:
Trying to register selector: 0x1017dc2e9/clazzMethod
Trying to register selector: 0x1017dc2f5/hello
Trying to register selector: 0x1017dc2fb/theSameProperty
Trying to register selector: 0x1017dc30b/uniqueProperty3
Trying to register selector: 0x1017dc32c/setTheSameProperty:
Trying to register selector: 0x1017dc340/setUniqueProperty1:
Trying to register selector: 0x1017dc354/uniqueProperty1
Trying to register selector: 0x1017dc386/setUniqueProperty2:
Trying to register selector: 0x1017dc39a/uniqueProperty2
Trying to register selector: 0x1017dc3bb/new
Trying to register selector: 0x1017dc3bf/stringWithFormat:
Trying to register selector: 0x1017dc3d1/raise
Trying to register selector: 0x1017dc3d7/reason
__objc_classrefs
__objc_superrefs
__objc_methname
__objc_classname
__objc_methtype
__objc_classlist
mull::objc::Runtime> adding class_t for later registration: 0x1017dc420, 64
mull::objc::Runtime> adding class: FirstClass_Subclass_Subclass
mull::objc::Runtime> adding class: FirstClass
mull::objc::Runtime> adding class: FirstClass_Subclass
mull::objc::Runtime> adding class: FooTest
registerClasses() FirstClass_Subclass_Subclass
registerClasses() superclass is not registered
registerClasses() FirstClass
registerClasses() superclass is registered
[method_list64_t]
	name: init
	types: @16@0:8
	imp: 0x1012fe210
[method_list64_t]
	name: hello
	types: c16@0:8
	imp: 0x1012fe2e0
[method_list64_t]
	name: theSameProperty
	types: @16@0:8
	imp: 0x1012fe360
[method_list64_t]
	name: setTheSameProperty:
	types: v24@0:8@16
	imp: 0x1012fe390
[method_list64_t]
	name: uniqueProperty1
	types: @16@0:8
	imp: 0x1012fe3d0
[method_list64_t]
	name: setUniqueProperty1:
	types: v24@0:8@16
	imp: 0x1012fe400
+++ Registering Class: FirstClass (0x105977180)
Dumping metaclass' methods
[method_list64_t]
	name: clazzMethod
	types: v16@0:8
	imp: 0x1012fe2b0
mull_dumpObjcMethods() dumping class: 0x105977180
Found 6 methods on 'FirstClass'
	'FirstClass' has method named 'setUniqueProperty1:' of encoding 'v24@0:8@16'
	'FirstClass' has method named 'uniqueProperty1' of encoding '@16@0:8'
	'FirstClass' has method named 'setTheSameProperty:' of encoding 'v24@0:8@16'
	'FirstClass' has method named 'theSameProperty' of encoding '@16@0:8'
	'FirstClass' has method named 'hello' of encoding 'c16@0:8'
	'FirstClass' has method named 'init' of encoding '@16@0:8'
mull_dumpObjcMethods() dumping class: 0x1059771b0
Found 1 methods on 'FirstClass'
	'FirstClass' has method named 'clazzMethod' of encoding 'v16@0:8'
registerClasses() FirstClass_Subclass
registerClasses() superclass is registered
registerClasses() superclass is registered
[method_list64_t]
	name: init
	types: @16@0:8
	imp: 0x1012fe440
[method_list64_t]
	name: hello
	types: c16@0:8
	imp: 0x1012fe530
[method_list64_t]
	name: uniqueProperty2
	types: @16@0:8
	imp: 0x1012fe5e0
[method_list64_t]
	name: setUniqueProperty2:
	types: v24@0:8@16
	imp: 0x1012fe610
+++ Registering Class: FirstClass_Subclass (0x105977440)
Dumping metaclass' methods
[method_list64_t]
	name: clazzMethod
	types: v16@0:8
	imp: 0x1012fe4c0
mull_dumpObjcMethods() dumping class: 0x105977440
Found 4 methods on 'FirstClass_Subclass'
	'FirstClass_Subclass' has method named 'setUniqueProperty2:' of encoding 'v24@0:8@16'
	'FirstClass_Subclass' has method named 'uniqueProperty2' of encoding '@16@0:8'
	'FirstClass_Subclass' has method named 'hello' of encoding 'c16@0:8'
	'FirstClass_Subclass' has method named 'init' of encoding '@16@0:8'
mull_dumpObjcMethods() dumping class: 0x105977470
Found 1 methods on 'FirstClass_Subclass'
	'FirstClass_Subclass' has method named 'clazzMethod' of encoding 'v16@0:8'
registerClasses() FooTest
registerClasses() superclass is registered
[method_list64_t]
	name: testFoo
	types: v16@0:8
	imp: 0x1012fe650
[method_list64_t]
	name: testFoo2
	types: v16@0:8
	imp: 0x1012fe960
+++ Registering Class: FooTest (0x101404fd0)
mull_dumpObjcMethods() dumping class: 0x101404fd0
Found 2 methods on 'FooTest'
	'FooTest' has method named 'testFoo2' of encoding 'v16@0:8'
	'FooTest' has method named 'testFoo' of encoding 'v16@0:8'
mull_dumpObjcMethods() dumping class: 0x101403770
Found 0 methods on 'FooTest'
registerClasses() FirstClass_Subclass_Subclass
registerClasses() superclass is registered
registerClasses() superclass is registered
[method_list64_t]
	name: init
	types: @16@0:8
	imp: 0x1012fe000
[method_list64_t]
	name: hello
	types: c16@0:8
	imp: 0x1012fe0f0
[method_list64_t]
	name: uniqueProperty3
	types: @16@0:8
	imp: 0x1012fe1a0
[method_list64_t]
	name: setUniqueProperty3:
	types: v24@0:8@16
	imp: 0x1012fe1d0
+++ Registering Class: FirstClass_Subclass_Subclass (0x105a00000)
Dumping metaclass' methods
[method_list64_t]
	name: clazzMethod
	types: v16@0:8
	imp: 0x1012fe080
mull_dumpObjcMethods() dumping class: 0x105a00000
Found 4 methods on 'FirstClass_Subclass_Subclass'
	'FirstClass_Subclass_Subclass' has method named 'setUniqueProperty3:' of encoding 'v24@0:8@16'
	'FirstClass_Subclass_Subclass' has method named 'uniqueProperty3' of encoding '@16@0:8'
	'FirstClass_Subclass_Subclass' has method named 'hello' of encoding 'c16@0:8'
	'FirstClass_Subclass_Subclass' has method named 'init' of encoding '@16@0:8'
mull_dumpObjcMethods() dumping class: 0x105a00030
Found 1 methods on 'FirstClass_Subclass_Subclass'
	'FirstClass_Subclass_Subclass' has method named 'clazzMethod' of encoding 'v16@0:8'
**** objc_printf ****
before test call
Test Suite 'All tests' started at 2018-03-20 20:19:27.003
2018-03-20 20:19:27.005378+0100 llvm-jit-lab[59311:21562136] testSuiteWillStart: <XCTestSuite:0x104108ea0, 1, All tests>
Test Suite 'Debug' started at 2018-03-20 20:19:27.005
2018-03-20 20:19:27.005532+0100 llvm-jit-lab[59311:21562136] testSuiteWillStart: <XCTestSuite:0x10410b810, 1, Debug>
Test Suite 'FooTest' started at 2018-03-20 20:19:27.006
2018-03-20 20:19:27.005648+0100 llvm-jit-lab[59311:21562136] testSuiteWillStart: <XCTestCaseSuite:0x10410b950, 2, FooTest>
Test Case '-[FooTest testFoo]' started.
2018-03-20 20:19:27.005808+0100 llvm-jit-lab[59311:21562136] testCaseWillStart: -[FooTest testFoo]
2018-03-20 20:19:27.355164+0100 llvm-jit-lab[59311:21562136] Success! Runtime sees the FooTest class!

2018-03-20 20:19:27.355225+0100 llvm-jit-lab[59311:21562136] FirstClass -hello: The same property FirstClass@uniqueProperty

2018-03-20 20:19:27.355244+0100 llvm-jit-lab[59311:21562136] FirstClass_Subclass -hello: The same property FirstClass_Subclass@uniqueProperty

2018-03-20 20:19:27.355260+0100 llvm-jit-lab[59311:21562136] FirstClass_Subclass_Subclass -hello: The same property FirstClass_Subclass_Subclass@uniqueProperty

Test Case '-[FooTest testFoo]' passed (0.350 seconds).
2018-03-20 20:19:27.355638+0100 llvm-jit-lab[59311:21562136] testCaseWillFinish: -[FooTest testFoo]
Test Case '-[FooTest testFoo2]' started.
2018-03-20 20:19:27.355728+0100 llvm-jit-lab[59311:21562136] testCaseWillStart: -[FooTest testFoo2]
SomeClass.mm:69: error: -[FooTest testFoo2] : ((NO) is true) failed
2018-03-20 20:19:27.355998+0100 llvm-jit-lab[59311:21562136] testCase:didFailWithDescription:inFile:atLine: -[FooTest testFoo2] ((NO) is true) failed SomeClass.mm 69
Test Case '-[FooTest testFoo2]' failed (0.000 seconds).
2018-03-20 20:19:27.356181+0100 llvm-jit-lab[59311:21562136] testCaseWillFinish: -[FooTest testFoo2]
Test Suite 'FooTest' failed at 2018-03-20 20:19:27.356.
	 Executed 2 tests, with 1 failure (0 unexpected) in 0.350 (0.351) seconds
2018-03-20 20:19:27.356378+0100 llvm-jit-lab[59311:21562136] testSuiteDidFinish: <XCTestCaseSuite:0x10410b950, 2, FooTest>
Test Suite 'Debug' failed at 2018-03-20 20:19:27.356.
	 Executed 2 tests, with 1 failure (0 unexpected) in 0.350 (0.351) seconds
2018-03-20 20:19:27.356451+0100 llvm-jit-lab[59311:21562136] testSuiteDidFinish: <XCTestSuite:0x10410b810, 1, Debug>
Test Suite 'All tests' failed at 2018-03-20 20:19:27.356.
	 Executed 2 tests, with 1 failure (0 unexpected) in 0.350 (0.354) seconds
2018-03-20 20:19:27.356517+0100 llvm-jit-lab[59311:21562136] testSuiteDidFinish: <XCTestSuite:0x104108ea0, 1, All tests>
2018-03-20 20:19:27.356531+0100 llvm-jit-lab[59311:21562136] MUT_RunXCTests: tests failed: 1
**** objc_printf ****
after test call
[0;32m[       OK ] [mLLVMJIT.ObjCRegistration (461 ms)
[0;32m[----------] [m1 test from LLVMJIT (461 ms total)

[0;32m[----------] [mGlobal test environment tear-down
[0;32m[==========] [m1 test from 1 test case ran. (461 ms total)
[0;32m[  PASSED  ] [m1 test.
Program ended with exit code: 0
```
